### PR TITLE
chore: Migrate patches from lower version

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+gvfs (1.54.2-2deepin1) unstable; urgency=medium
+
+  * add ftp charset support.
+  * add ftp socket timeout support.
+  * fix smb browse fail for netreset error.
+  * smb create dummy stat for root dir where access is denied.
+  * smb set default location to topmost dir.
+
+ -- wangrong <wangrong@uniontech.com>  Thu, 22 Aug 2024 11:27:03 +0800
+
 gvfs (1.54.2-2) unstable; urgency=medium
 
   * Stop building the afc backend on i386

--- a/debian/patches/add-ftp-charset.patch
+++ b/debian/patches/add-ftp-charset.patch
@@ -1,0 +1,386 @@
+From: rong wang <wangrong@uniontech.com>
+Date: Tue Apr 11 10:56:23 2023 +0800
+Subject: [PATCH] feat: ftp mount support charset setting
+
+ftp mount supports setting charset via uri, like "ftp://ip?charset=GBK".
+The default value of charset is "UTF-8". If the set charset does not
+support it will cause the mount to fail.
+---
+Index: gvfs-1.54.2/daemon/gvfsbackendftp.c
+===================================================================
+--- gvfs-1.54.2.orig/daemon/gvfsbackendftp.c
++++ gvfs-1.54.2/daemon/gvfsbackendftp.c
+@@ -392,6 +392,7 @@ g_vfs_backend_ftp_finalize (GObject *obj
+ 
+   g_free (ftp->user);
+   g_free (ftp->password);
++  g_free (ftp->charset);
+ 
+   g_clear_object (&ftp->server_identity);
+   g_clear_object (&ftp->certificate);
+@@ -449,7 +450,7 @@ do_mount (GVfsBackend *backend,
+   guint port, default_port;
+ 
+ restart:
+-  task.conn = g_vfs_ftp_connection_new (ftp->addr, ftp->socket_timeout, task.cancellable, &task.error);
++  task.conn = g_vfs_ftp_connection_new (ftp->addr, ftp->socket_timeout, ftp->charset, task.cancellable, &task.error);
+   /* fail fast here. No need to ask for a password if we know the hostname
+    * doesn't exist or the given host/port doesn't have an ftp server running.
+    */
+@@ -697,36 +698,6 @@ try_login:
+   g_vfs_ftp_task_done (&task);
+ }
+ 
+-static int
+-enum_query (char **query, char key[], char value[], int size)
+-{
+-  char *end;
+-  int _size;
+-
+-  if (0 == query || 0 == *query || 0 == **query)
+-    return 0;
+-
+-  end = strstr(*query, "=");
+-  if (0 == end)
+-    return 0;
+-  _size = end - *query + 1;
+-  if (_size > size)
+-    return 0;
+-  memcpy (key, *query, _size);
+-  key[_size - 1] = 0;
+-  *query = end + 1;
+-
+-  end = strstr(*query, "&");
+-  _size = (0 == end) ? (strlen(*query) + 1) : (end - *query + 1);
+-  if (_size > size)
+-    return 0;
+-  memcpy (value, *query, _size);
+-  value[_size - 1] = 0;
+-  *query = (0 == end) ? 0 : end + 1;
+-
+-  return 1;
+-}
+-
+ static gboolean
+ try_mount (GVfsBackend *backend,
+           GVfsJobMount *job,
+@@ -735,9 +706,11 @@ try_mount (GVfsBackend *backend,
+           gboolean is_automount)
+ {
+   GVfsBackendFtp *ftp = G_VFS_BACKEND_FTP (backend);
+-  const char *type, *host, *port_str, *query;
++  const char *type, *host, *port_str;
+   guint port;
+-  char key[128], value[sizeof(key)];
++  GHashTable *params = NULL;
++  GError *error = NULL;
++  gboolean ret = TRUE;
+ 
+   type = g_mount_spec_get_type (mount_spec);
+   if (g_strcmp0 (type, "ftps") == 0)
+@@ -753,7 +726,7 @@ try_mount (GVfsBackend *backend,
+       g_vfs_job_failed (G_VFS_JOB (job),
+                        G_IO_ERROR, G_IO_ERROR_INVALID_ARGUMENT,
+                        _("No hostname specified"));
+-      return TRUE;
++      goto quit;
+     }
+   port_str = g_mount_spec_get (mount_spec, "port");
+   if (port_str == NULL)
+@@ -777,17 +750,45 @@ try_mount (GVfsBackend *backend,
+   if (ftp->tls_mode != G_VFS_FTP_TLS_MODE_NONE)
+     ftp->server_identity = g_object_ref (ftp->addr);
+ 
+-  query = g_mount_spec_get (mount_spec, "query");
++  if (g_mount_spec_get (mount_spec, "query") == NULL)
++    {
++      ret = FALSE;
++      goto quit;
++    }
++
++  params = g_uri_parse_params (g_mount_spec_get (mount_spec, "query"), -1, "&", G_URI_PARAMS_CASE_INSENSITIVE, &error);
++  if (params == NULL)
++    {
++      g_vfs_job_failed_from_error (G_VFS_JOB (job), error);
++      goto quit;
++    }
++
+   ftp->socket_timeout = 0;
+-  while (enum_query(&query, key, value, sizeof(key)))
++  if (g_hash_table_contains (params, "socket_timeout"))
++    {
++      ftp->socket_timeout = strtoul ((gchar*) g_hash_table_lookup (params, "socket_timeout"), NULL, 10);
++    }
++  ftp->charset = g_strdup ((gchar*) g_hash_table_lookup (params, "charset"));
++  if (ftp->charset)
+     {
+-      if (strcmp(key, "socket_timeout") == 0)
++      GConverter *conv;
++
++      conv = (GConverter *) g_charset_converter_new ("UTF-8", ftp->charset, &error);
++      if (conv == NULL)
+         {
+-          ftp->socket_timeout = strtoul(value, NULL, 10);
++          g_vfs_job_failed_from_error (G_VFS_JOB (job), error);
++          goto quit;
+         }
++      else
++        g_object_unref (conv);
+     }
+ 
+-  return FALSE;
++  ret = FALSE;
++
++quit:
++  g_clear_pointer (&params, g_hash_table_unref);
++  g_clear_error (&error);
++  return ret;
+ }
+ 
+ static void
+Index: gvfs-1.54.2/daemon/gvfsbackendftp.h
+===================================================================
+--- gvfs-1.54.2.orig/daemon/gvfsbackendftp.h
++++ gvfs-1.54.2/daemon/gvfsbackendftp.h
+@@ -124,6 +124,7 @@ struct _GVfsBackendFtp
+   guint                	max_connections;        /* upper server limit for number of connections - dynamically generated */
+ 
+   guint                 socket_timeout;
++  char *                charset;
+ };
+ 
+ struct _GVfsBackendFtpClass
+Index: gvfs-1.54.2/daemon/gvfsftpconnection.c
+===================================================================
+--- gvfs-1.54.2.orig/daemon/gvfsftpconnection.c
++++ gvfs-1.54.2/daemon/gvfsftpconnection.c
+@@ -40,12 +40,14 @@ struct _GVfsFtpConnection
+   GIOStream *        	commands;               /* ftp command stream */
+   GSocketConnection *   connection;             /* original connection */
+   GDataInputStream *    commands_in;            /* wrapper around in stream to allow line-wise reading */
++  GOutputStream *       commands_out;           /* wrapper around out stream to convert charset */
+   gboolean              waiting_for_reply;           /* TRUE if a command was sent but no reply received yet */
+ 
+   GSocket *             listen_socket;          /* socket we are listening on for active FTP connections */
+   GIOStream *        	data;                   /* ftp data stream or NULL if not in use */
+ 
+   int                   debug_id;               /* unique id for debugging purposes */
++  char *                charset;                /* ftp server charset */
+ };
+ 
+ static void
+@@ -82,19 +84,67 @@ enable_nodelay (GSocketConnection *conn)
+ static void
+ create_input_stream (GVfsFtpConnection *conn)
+ {
++  GInputStream *convert_stream;
++  GConverter *conv;
++
+   if (conn->commands_in)
+     {
+-      g_filter_input_stream_set_close_base_stream (G_FILTER_INPUT_STREAM (conn->commands_in), FALSE);
++      if (conn->charset)
++        {
++          convert_stream = g_filter_input_stream_get_base_stream (G_FILTER_INPUT_STREAM (conn->commands_in));
++          g_filter_input_stream_set_close_base_stream (G_FILTER_INPUT_STREAM (convert_stream), FALSE);
++        }
++      else
++        g_filter_input_stream_set_close_base_stream (G_FILTER_INPUT_STREAM (conn->commands_in), FALSE);
+       g_object_unref (conn->commands_in);
+     }
+ 
+-  conn->commands_in = G_DATA_INPUT_STREAM (g_data_input_stream_new (g_io_stream_get_input_stream (conn->commands)));
++  if (conn->charset)
++    {
++      conv = (GConverter *) g_charset_converter_new ("UTF-8", conn->charset, NULL);
++      g_charset_converter_set_use_fallback ((GCharsetConverter *) conv, TRUE);
++      convert_stream = (GInputStream *) g_converter_input_stream_new (g_io_stream_get_input_stream (conn->commands), conv);
++      g_object_unref (conv);
++      conn->commands_in = G_DATA_INPUT_STREAM (g_data_input_stream_new (convert_stream));
++      g_object_unref (convert_stream);
++    }
++  else
++    conn->commands_in = G_DATA_INPUT_STREAM (g_data_input_stream_new (g_io_stream_get_input_stream (conn->commands)));
++
+   g_data_input_stream_set_newline_type (conn->commands_in, G_DATA_STREAM_NEWLINE_TYPE_CR_LF);
+ }
+ 
++static void
++create_output_stream (GVfsFtpConnection *conn)
++{
++  GConverter *conv;
++
++  if (conn->commands_out)
++    {
++      if (conn->charset)
++        g_filter_output_stream_set_close_base_stream (G_FILTER_OUTPUT_STREAM (conn->commands_out), FALSE);
++      g_object_unref (conn->commands_out);
++    }
++
++  if (conn->charset)
++    {
++      conv = (GConverter *) g_charset_converter_new (conn->charset, "UTF-8", NULL);
++      g_charset_converter_set_use_fallback ((GCharsetConverter *) conv, TRUE);
++      conn->commands_out = G_OUTPUT_STREAM (g_converter_output_stream_new (g_io_stream_get_output_stream (conn->commands), conv));
++      g_object_unref (conv);
++    }
++  else
++    {
++      conn->commands_out = g_io_stream_get_output_stream (conn->commands);
++      g_object_ref (conn->commands_out);
++    }
++
++}
++
+ GVfsFtpConnection *
+ g_vfs_ftp_connection_new (GSocketConnectable *addr,
+                           guint               socket_timeout,
++                          char *              charset,
+                           GCancellable *      cancellable,
+                           GError **           error)
+ {
+@@ -106,6 +156,7 @@ g_vfs_ftp_connection_new (GSocketConnect
+   conn->client = g_socket_client_new ();
+   g_socket_client_set_timeout(conn->client, socket_timeout);
+   conn->debug_id = g_atomic_int_add (&debug_id, 1);
++  conn->charset = g_strdup (charset);
+   conn->commands = G_IO_STREAM (g_socket_client_connect (conn->client,
+                                                          addr,
+                                                          cancellable,
+@@ -121,6 +172,7 @@ g_vfs_ftp_connection_new (GSocketConnect
+   enable_nodelay (conn->connection);
+   enable_keepalive (conn->connection);
+   create_input_stream (conn);
++  create_output_stream (conn);
+   /* The first thing that needs to happen is receiving the welcome message */
+   conn->waiting_for_reply = TRUE;
+ 
+@@ -145,8 +197,10 @@ g_vfs_ftp_connection_free (GVfsFtpConnec
+   g_vfs_ftp_connection_stop_listening (conn);
+   g_vfs_ftp_connection_close_data_connection (conn);
+ 
++  g_object_unref (conn->commands_out);
+   g_object_unref (conn->commands_in);
+   g_object_unref (conn->commands);
++  g_free (conn->charset);
+   g_object_unref (conn->client);
+   g_slice_free (GVfsFtpConnection, conn);
+ }
+@@ -172,7 +226,7 @@ g_vfs_ftp_connection_send (GVfsFtpConnec
+     g_debug ("--%2d ->  %s", conn->debug_id, command);
+ 
+   conn->waiting_for_reply = TRUE;
+-  return g_output_stream_write_all (g_io_stream_get_output_stream (conn->commands),
++  return g_output_stream_write_all (conn->commands_out,
+                                     command,
+                                     len,
+                                     NULL,
+@@ -529,6 +583,38 @@ g_vfs_ftp_connection_get_debug_id (GVfsF
+ }
+ 
+ /**
++ * g_vfs_ftp_connection_get_charset_data_output_stream:
++ * @conn: the connection
++ *
++ * Gets the data output stream that support charset conversion.
++ *
++ * Returns: the data output stream that support charset conversion
++ **/
++GInputStream *
++g_vfs_ftp_connection_new_data_input_stream_with_charset (GVfsFtpConnection *      conn)
++{
++  GInputStream *stream;
++  GConverter *conv;
++
++  g_return_val_if_fail (conn != NULL, NULL);
++  g_return_val_if_fail (conn->data != NULL, NULL);
++
++  if (conn->charset == NULL)
++    {
++      stream = g_io_stream_get_input_stream (conn->data);
++      g_object_ref (stream);
++      return stream;
++    }
++
++  conv = (GConverter *) g_charset_converter_new ("UTF-8", conn->charset, NULL);
++  g_charset_converter_set_use_fallback ((GCharsetConverter *) conv, TRUE);
++  stream = (GInputStream *) g_converter_input_stream_new (g_io_stream_get_input_stream (conn->data), conv);
++  g_object_unref (conv);
++
++  return stream;
++}
++
++/**
+  * g_vfs_ftp_connection_get_data_stream:
+  * @conn: a connection
+  *
+@@ -623,6 +709,7 @@ g_vfs_ftp_connection_enable_tls (GVfsFtp
+   g_object_unref (conn->commands);
+   conn->commands = secure;
+   create_input_stream (conn);
++  create_output_stream (conn);
+ 
+   g_signal_connect (secure, "accept-certificate", G_CALLBACK (cb), user_data);
+ 
+Index: gvfs-1.54.2/daemon/gvfsftpconnection.h
+===================================================================
+--- gvfs-1.54.2.orig/daemon/gvfsftpconnection.h
++++ gvfs-1.54.2/daemon/gvfsftpconnection.h
+@@ -37,6 +37,7 @@ typedef gboolean      (*CertificateCallb
+ 
+ GVfsFtpConnection *     g_vfs_ftp_connection_new              (GSocketConnectable *     addr,
+                                                                guint                    socket_timeout,
++                                                               char *                   charset,
+                                                                GCancellable *           cancellable,
+                                                                GError **                error);
+ void                    g_vfs_ftp_connection_free             (GVfsFtpConnection *      conn);
+@@ -55,6 +56,8 @@ gboolean                g_vfs_ftp_connec
+ GSocketAddress *        g_vfs_ftp_connection_get_address      (GVfsFtpConnection *      conn,
+                                                                GError **                error);
+ guint                   g_vfs_ftp_connection_get_debug_id     (GVfsFtpConnection *      conn);
++GInputStream *          g_vfs_ftp_connection_new_data_input_stream_with_charset
++                                                              (GVfsFtpConnection *      conn);
+ 
+ gboolean                g_vfs_ftp_connection_open_data_connection
+                                                               (GVfsFtpConnection *      conn,
+Index: gvfs-1.54.2/daemon/gvfsftpdircache.c
+===================================================================
+--- gvfs-1.54.2.orig/daemon/gvfsftpdircache.c
++++ gvfs-1.54.2/daemon/gvfsftpdircache.c
+@@ -137,6 +137,7 @@ g_vfs_ftp_dir_cache_lookup_entry (GVfsFt
+                                   guint              stamp)
+ {
+   GVfsFtpDirCacheEntry *entry;
++  GInputStream *data_input_stream;
+ 
+   g_mutex_lock (&cache->lock);
+   entry = g_hash_table_lookup (cache->directories, dir);
+@@ -165,12 +166,14 @@ g_vfs_ftp_dir_cache_lookup_entry (GVfsFt
+     return NULL;
+ 
+   entry = g_vfs_ftp_dir_cache_entry_new (stamp);
+-  cache->funcs->process (g_io_stream_get_input_stream (g_vfs_ftp_connection_get_data_stream (task->conn)),
++  data_input_stream = g_vfs_ftp_connection_new_data_input_stream_with_charset (task->conn);
++  cache->funcs->process (data_input_stream,
+                          g_vfs_ftp_connection_get_debug_id (task->conn),
+                          dir,
+                          entry,
+                          task->cancellable,
+                          &task->error);
++  g_object_unref (data_input_stream);
+   g_vfs_ftp_task_close_data_connection (task);
+   g_vfs_ftp_task_receive (task, 0, NULL);
+   if (g_vfs_ftp_task_is_in_error (task))
+Index: gvfs-1.54.2/daemon/gvfsftptask.c
+===================================================================
+--- gvfs-1.54.2.orig/daemon/gvfsftptask.c
++++ gvfs-1.54.2/daemon/gvfsftptask.c
+@@ -248,7 +248,7 @@ g_vfs_ftp_task_acquire_connection (GVfsF
+           ftp->connections++;
+           last_thread = g_thread_self ();
+           g_mutex_unlock (&ftp->mutex);
+-          task->conn = g_vfs_ftp_connection_new (ftp->addr, ftp->socket_timeout, task->cancellable, &task->error);
++          task->conn = g_vfs_ftp_connection_new (ftp->addr, ftp->socket_timeout, ftp->charset, task->cancellable, &task->error);
+           if (G_LIKELY (task->conn != NULL))
+             {
+               g_vfs_ftp_task_initial_handshake (task, reconnect_certificate_cb, ftp);

--- a/debian/patches/add-ftp-socket-timeout.patch
+++ b/debian/patches/add-ftp-socket-timeout.patch
@@ -1,0 +1,144 @@
+From: rong wang <wangrong@uniontech.com>
+Date: Mon Sep 19 10:53:35 2022 +0800
+Subject: [PATCH] feat: ftp mount support socket timeout setting
+
+ftp mount supports setting socket timeout via uri, like
+"ftp://ip?socket_time=3". The unit of socket_time is seconds, the
+default value is 0, which means to wait all the time.
+---
+Index: gvfs-1.54.2/daemon/gvfsbackendftp.c
+===================================================================
+--- gvfs-1.54.2.orig/daemon/gvfsbackendftp.c
++++ gvfs-1.54.2/daemon/gvfsbackendftp.c
+@@ -449,7 +449,7 @@ do_mount (GVfsBackend *backend,
+   guint port, default_port;
+ 
+ restart:
+-  task.conn = g_vfs_ftp_connection_new (ftp->addr, task.cancellable, &task.error);
++  task.conn = g_vfs_ftp_connection_new (ftp->addr, ftp->socket_timeout, task.cancellable, &task.error);
+   /* fail fast here. No need to ask for a password if we know the hostname
+    * doesn't exist or the given host/port doesn't have an ftp server running.
+    */
+@@ -697,6 +697,36 @@ try_login:
+   g_vfs_ftp_task_done (&task);
+ }
+ 
++static int
++enum_query (char **query, char key[], char value[], int size)
++{
++  char *end;
++  int _size;
++
++  if (0 == query || 0 == *query || 0 == **query)
++    return 0;
++
++  end = strstr(*query, "=");
++  if (0 == end)
++    return 0;
++  _size = end - *query + 1;
++  if (_size > size)
++    return 0;
++  memcpy (key, *query, _size);
++  key[_size - 1] = 0;
++  *query = end + 1;
++
++  end = strstr(*query, "&");
++  _size = (0 == end) ? (strlen(*query) + 1) : (end - *query + 1);
++  if (_size > size)
++    return 0;
++  memcpy (value, *query, _size);
++  value[_size - 1] = 0;
++  *query = (0 == end) ? 0 : end + 1;
++
++  return 1;
++}
++
+ static gboolean
+ try_mount (GVfsBackend *backend,
+           GVfsJobMount *job,
+@@ -705,8 +735,9 @@ try_mount (GVfsBackend *backend,
+           gboolean is_automount)
+ {
+   GVfsBackendFtp *ftp = G_VFS_BACKEND_FTP (backend);
+-  const char *type, *host, *port_str;
++  const char *type, *host, *port_str, *query;
+   guint port;
++  char key[128], value[sizeof(key)];
+ 
+   type = g_mount_spec_get_type (mount_spec);
+   if (g_strcmp0 (type, "ftps") == 0)
+@@ -746,6 +777,16 @@ try_mount (GVfsBackend *backend,
+   if (ftp->tls_mode != G_VFS_FTP_TLS_MODE_NONE)
+     ftp->server_identity = g_object_ref (ftp->addr);
+ 
++  query = g_mount_spec_get (mount_spec, "query");
++  ftp->socket_timeout = 0;
++  while (enum_query(&query, key, value, sizeof(key)))
++    {
++      if (strcmp(key, "socket_timeout") == 0)
++        {
++          ftp->socket_timeout = strtoul(value, NULL, 10);
++        }
++    }
++
+   return FALSE;
+ }
+ 
+Index: gvfs-1.54.2/daemon/gvfsbackendftp.h
+===================================================================
+--- gvfs-1.54.2.orig/daemon/gvfsbackendftp.h
++++ gvfs-1.54.2/daemon/gvfsbackendftp.h
+@@ -122,6 +122,8 @@ struct _GVfsBackendFtp
+   guint                	connections;            /* current number of connections */
+   guint                 busy_connections;       /* current number of connections being used for reads/writes */
+   guint                	max_connections;        /* upper server limit for number of connections - dynamically generated */
++
++  guint                 socket_timeout;
+ };
+ 
+ struct _GVfsBackendFtpClass
+Index: gvfs-1.54.2/daemon/gvfsftpconnection.c
+===================================================================
+--- gvfs-1.54.2.orig/daemon/gvfsftpconnection.c
++++ gvfs-1.54.2/daemon/gvfsftpconnection.c
+@@ -94,6 +94,7 @@ create_input_stream (GVfsFtpConnection *
+ 
+ GVfsFtpConnection *
+ g_vfs_ftp_connection_new (GSocketConnectable *addr,
++                          guint               socket_timeout,
+                           GCancellable *      cancellable,
+                           GError **           error)
+ {
+@@ -103,6 +104,7 @@ g_vfs_ftp_connection_new (GSocketConnect
+ 
+   conn = g_slice_new0 (GVfsFtpConnection);
+   conn->client = g_socket_client_new ();
++  g_socket_client_set_timeout(conn->client, socket_timeout);
+   conn->debug_id = g_atomic_int_add (&debug_id, 1);
+   conn->commands = G_IO_STREAM (g_socket_client_connect (conn->client,
+                                                          addr,
+Index: gvfs-1.54.2/daemon/gvfsftpconnection.h
+===================================================================
+--- gvfs-1.54.2.orig/daemon/gvfsftpconnection.h
++++ gvfs-1.54.2/daemon/gvfsftpconnection.h
+@@ -36,6 +36,7 @@ typedef gboolean      (*CertificateCallb
+                                                                gpointer                 user_data);
+ 
+ GVfsFtpConnection *     g_vfs_ftp_connection_new              (GSocketConnectable *     addr,
++                                                               guint                    socket_timeout,
+                                                                GCancellable *           cancellable,
+                                                                GError **                error);
+ void                    g_vfs_ftp_connection_free             (GVfsFtpConnection *      conn);
+Index: gvfs-1.54.2/daemon/gvfsftptask.c
+===================================================================
+--- gvfs-1.54.2.orig/daemon/gvfsftptask.c
++++ gvfs-1.54.2/daemon/gvfsftptask.c
+@@ -248,7 +248,7 @@ g_vfs_ftp_task_acquire_connection (GVfsF
+           ftp->connections++;
+           last_thread = g_thread_self ();
+           g_mutex_unlock (&ftp->mutex);
+-          task->conn = g_vfs_ftp_connection_new (ftp->addr, task->cancellable, &task->error);
++          task->conn = g_vfs_ftp_connection_new (ftp->addr, ftp->socket_timeout, task->cancellable, &task->error);
+           if (G_LIKELY (task->conn != NULL))
+             {
+               g_vfs_ftp_task_initial_handshake (task, reconnect_certificate_cb, ftp);

--- a/debian/patches/fix-smb-browse-fail-for-netreset-error.patch
+++ b/debian/patches/fix-smb-browse-fail-for-netreset-error.patch
@@ -1,0 +1,27 @@
+From: rong wang <wangrong@uniontech.com>
+Date: Wed Aug 9 14:28:46 2023 +0800
+Subject: [PATCH] fix: smb browse fail for netreset error
+
+When using libsmbclient to log in to some NAS servers anonymously, the
+NAS will disconnect directly when it finds that the login is anonymous.
+As a result, gio failed to mount smb. The solution is to use the
+account to log in again if it is judged that an error netreset is
+reported during the first anonymous login.
+---
+Index: gvfs-1.54.2/daemon/gvfsbackendsmbbrowse.c
+===================================================================
+--- gvfs-1.54.2.orig/daemon/gvfsbackendsmbbrowse.c
++++ gvfs-1.54.2/daemon/gvfsbackendsmbbrowse.c
+@@ -757,7 +757,11 @@ do_mount (GVfsBackend *backend,
+              uri, op_backend->mount_try, dir, op_backend->mount_cancelled,
+              errsv, g_strerror (errsv));
+ 
+-      if (errsv == EINVAL && op_backend->mount_try == 0 && op_backend->user == NULL)
++      if (errsv == ENETRESET && op_backend->mount_try == 0 && op_backend->user == NULL)
++        {
++          /* ENETRESET is "expected" when accessing some NAS servers anonymously */
++        }
++      else if (errsv == EINVAL && op_backend->mount_try == 0 && op_backend->user == NULL)
+         {
+           /* EINVAL is "expected" when kerberos is misconfigured, see:
+            * https://gitlab.gnome.org/GNOME/gvfs/-/issues/611

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -5,3 +5,8 @@ ref-jobs-in-thread.patch
 0008-Skip-the-umockdev-test.patch
 0009-gvfs-test-Increase-timeout-to-10s.patch
 Remove-version-from-polkit-gobject-dependency.patch
+smb-create-dummy-stat-for-root-dir-where-access-is-denied.patch
+smb-set-default-location-to-topmost-dir.patch
+add-ftp-socket-timeout.patch
+fix-smb-browse-fail-for-netreset-error.patch
+add-ftp-charset.patch

--- a/debian/patches/smb-create-dummy-stat-for-root-dir-where-access-is-denied.patch
+++ b/debian/patches/smb-create-dummy-stat-for-root-dir-where-access-is-denied.patch
@@ -1,0 +1,42 @@
+From 7e37b07a45ad7e6f918ca2b3852bda6e82230391 Mon Sep 17 00:00:00 2001
+From: rong wang <wangrong@uniontech.com>
+Date: Fri, 7 Jun 2024 10:35:04 +0800
+Subject: [PATCH] smb: Create dummy stat for root dir where access is denied
+
+Due to permission control, some backends will report an error (EACCES)
+when getting the root directory attributes, but can access
+subdirectories normally. Therefore, we need to construct a dummy stat
+for the root directory so that the application (such as gvfsd-fuse) can
+smoothly traverse the root directory when accessing subdirectories.
+---
+ daemon/gvfsbackendsmb.c | 14 ++++++++++++++
+ 1 file changed, 14 insertions(+)
+
+diff --git a/daemon/gvfsbackendsmb.c b/daemon/gvfsbackendsmb.c
+index cc0fb7eb..b26b7162 100644
+--- a/daemon/gvfsbackendsmb.c
++++ b/daemon/gvfsbackendsmb.c
+@@ -1571,6 +1571,20 @@ do_query_info (GVfsBackend *backend,
+   saved_errno = errno;
+   g_free (uri);
+ 
++  /* Create dummy stat for root dir where access is denied */
++  if (saved_errno == EACCES || saved_errno == EPERM)
++    {
++      /* Check if the file name is part of the user's mount path */
++      if (g_str_equal (filename, "/") ||
++          (g_str_has_prefix (op_backend->path, filename) &&
++           op_backend->path[strlen (filename)] == '/'))
++        {
++          st.st_mode = S_IFDIR | 0500;
++
++          res = saved_errno = 0;
++        }
++    }
++
+   if (res == 0)
+     {
+       basename = g_path_get_basename (filename);
+-- 
+GitLab
+

--- a/debian/patches/smb-set-default-location-to-topmost-dir.patch
+++ b/debian/patches/smb-set-default-location-to-topmost-dir.patch
@@ -1,0 +1,69 @@
+From c8170f99fa8d15235dca6ded2d75024b63e28b4b Mon Sep 17 00:00:00 2001
+From: rong wang <wangrong@uniontech.com>
+Date: Tue, 9 Jul 2024 17:18:36 +0800
+Subject: [PATCH] smb: Set default location to topmost dir
+
+Because the mount operation might be triggered from other places than
+just from the "Connect to server" bar and consequently the default
+location might be set to something nonsensical, even to regular file.
+Let's set default location to topmost dir.
+---
+ daemon/gvfsbackendsmb.c | 35 ++++++++++++++++++++++++++++++++++-
+ 1 file changed, 34 insertions(+), 1 deletion(-)
+
+diff --git a/daemon/gvfsbackendsmb.c b/daemon/gvfsbackendsmb.c
+index b26b7162..66dbc441 100644
+--- a/daemon/gvfsbackendsmb.c
++++ b/daemon/gvfsbackendsmb.c
+@@ -381,6 +381,39 @@ create_smb_uri (const char *server,
+   return g_string_free (uri, FALSE);
+ }
+ 
++static void
++set_default_location_to_topmost_dir (GVfsBackend  *backend,
++                                     const char   *mount_path)
++{
++  GVfsBackendSmb *op_backend = G_VFS_BACKEND_SMB (backend);
++  struct stat st;
++  char *uri;
++  int res;
++  char *last_good_path, *new_path;
++  smbc_stat_fn smbc_stat;
++
++  smbc_stat = smbc_getFunctionStat (op_backend->smb_context);
++  last_good_path = g_strdup (mount_path);
++
++  while (!g_str_equal (last_good_path, "/"))
++    {
++      new_path = g_path_get_dirname (last_good_path);
++      uri = create_smb_uri (op_backend->server, op_backend->port, op_backend->share, new_path);
++      res = smbc_stat (op_backend->smb_context, uri, &st);
++      g_free (uri);
++      if (res != 0)
++        {
++          g_free (new_path);
++          break;
++        }
++      g_free (last_good_path);
++      last_good_path = new_path;
++    }
++
++  g_vfs_backend_set_default_location (backend, last_good_path);
++  g_free (last_good_path);
++}
++
+ static void
+ do_mount (GVfsBackend *backend,
+ 	  GVfsJobMount *job,
+@@ -560,7 +593,7 @@ do_mount (GVfsBackend *backend,
+   /* Mount was successful */
+   g_debug ("do_mount - login successful\n");
+ 
+-  g_vfs_backend_set_default_location (backend, op_backend->path);
++  set_default_location_to_topmost_dir (backend, op_backend->path);
+   g_vfs_keyring_save_password (op_backend->last_user,
+ 			       op_backend->server,
+ 			       op_backend->last_domain,
+-- 
+GitLab
+


### PR DESCRIPTION
* add ftp charset support.
* add ftp socket timeout support.
* fix smb browse fail for netreset error.
* smb create dummy stat for root dir where access is denied.
* smb set default location to topmost dir.

Log: migrate patches from lower version.
Task: https://pms.uniontech.com/task-view-358079.html