### PR TITLE
Fix CVE-2026-28295 and CVE-2026-28296: FTP security vulnerabilities

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+gvfs (1.54.2-2deepin3) unstable; urgency=medium
+
+  * Fix CVE-2026-28295: FTP PASV response SSRF vulnerability
+
+ -- deepin-ci-robot <packages@deepin.org>  Thu, 08 May 2026 00:00:00 +0800
+
 gvfs (1.54.2-2deepin2) unstable; urgency=medium
 
   * add sftp monitor.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 gvfs (1.54.2-2deepin3) unstable; urgency=medium
 
   * Fix CVE-2026-28295: FTP PASV response SSRF vulnerability
+  * Fix CVE-2026-28296: FTP path CRLF injection vulnerability
 
  -- deepin-ci-robot <packages@deepin.org>  Thu, 08 May 2026 00:00:00 +0800
 

--- a/debian/patches/CVE-2026-28295.patch
+++ b/debian/patches/CVE-2026-28295.patch
@@ -1,0 +1,135 @@
+Index: github-gvfs-CVE-2026-28295/daemon/gvfsbackendftp.c
+===================================================================
+--- github-gvfs-CVE-2026-28295.orig/daemon/gvfsbackendftp.c
++++ github-gvfs-CVE-2026-28295/daemon/gvfsbackendftp.c
+@@ -63,9 +63,8 @@
+  * GVfsFtpMethod:
+  * @G_VFS_FTP_METHOD_UNKNOWN: method has not yet been determined
+  * @G_VFS_FTP_METHOD_EPSV: use EPSV command
+- * @G_VFS_FTP_METHOD_PASV: use PASV command
+- * @G_VFS_FTP_METHOD_PASV_ADDR: use PASV command, but ignore the returned 
+- *                              address and only use it's port
++ * @G_VFS_FTP_METHOD_PASV: use PASV command, but ignore the returned address
++ *                         and only use it's port (bounce attack prevention)
+  * @G_VFS_FTP_METHOD_EPRT: use the EPRT command
+  * @G_VFS_FTP_METHOD_PORT: use the PORT command
+  *
+Index: github-gvfs-CVE-2026-28295/daemon/gvfsbackendftp.h
+===================================================================
+--- github-gvfs-CVE-2026-28295.orig/daemon/gvfsbackendftp.h
++++ github-gvfs-CVE-2026-28295/daemon/gvfsbackendftp.h
+@@ -61,7 +61,6 @@ typedef enum {
+   G_VFS_FTP_METHOD_ANY = 0,
+   G_VFS_FTP_METHOD_EPSV,
+   G_VFS_FTP_METHOD_PASV,
+-  G_VFS_FTP_METHOD_PASV_ADDR,
+   G_VFS_FTP_METHOD_EPRT,
+   G_VFS_FTP_METHOD_PORT
+ } GVfsFtpMethod;
+Index: github-gvfs-CVE-2026-28295/daemon/gvfsftptask.c
+===================================================================
+--- github-gvfs-CVE-2026-28295.orig/daemon/gvfsftptask.c
++++ github-gvfs-CVE-2026-28295/daemon/gvfsftptask.c
+@@ -858,7 +858,7 @@ fail:
+ static GVfsFtpMethod
+ g_vfs_ftp_task_setup_data_connection_pasv (GVfsFtpTask *task, GVfsFtpMethod method)
+ {
+-  guint ip1, ip2, ip3, ip4, port1, port2;
++  guint port1, port2;
+   char **reply;
+   const char *s;
+   GSocketAddress *addr;
+@@ -874,10 +874,8 @@ g_vfs_ftp_task_setup_data_connection_pas
+    */
+   for (s = reply[0]; *s; s++)
+     {
+-      if (sscanf (s, "%u,%u,%u,%u,%u,%u",
+-        	 &ip1, &ip2, &ip3, &ip4,
+-        	 &port1, &port2) == 6)
+-       break;
++      if (sscanf (s, "%*u,%*u,%*u,%*u,%u,%u", &port1, &port2) == 2)
++        break;
+     }
+   if (*s == 0)
+     {
+@@ -888,52 +886,16 @@ g_vfs_ftp_task_setup_data_connection_pas
+     }
+   g_strfreev (reply);
+ 
+-  if (method == G_VFS_FTP_METHOD_PASV || method == G_VFS_FTP_METHOD_ANY)
+-    {
+-      guint8 ip[4];
+-      GInetAddress *inet_addr;
+-
+-      ip[0] = ip1;
+-      ip[1] = ip2;
+-      ip[2] = ip3;
+-      ip[3] = ip4;
+-      inet_addr = g_inet_address_new_from_bytes (ip, G_SOCKET_FAMILY_IPV4);
+-      addr = g_inet_socket_address_new (inet_addr, port1 << 8 | port2);
+-      g_object_unref (inet_addr);
+-
+-      success = g_vfs_ftp_connection_open_data_connection (task->conn,
+-                                                           addr,
+-                                                           task->cancellable,
+-                                                           &task->error);
+-      g_object_unref (addr);
+-      if (success)
+-        return G_VFS_FTP_METHOD_PASV;
+-      if (g_vfs_ftp_task_is_in_error (task) && method != G_VFS_FTP_METHOD_ANY)
+-        return G_VFS_FTP_METHOD_ANY;
+-
+-      g_vfs_ftp_task_clear_error (task);
+-    }
+-
+-  if (method == G_VFS_FTP_METHOD_PASV_ADDR || method == G_VFS_FTP_METHOD_ANY)
+-    {
+-      /* Workaround code:
+-       * Various ftp servers aren't setup correctly when behind a NAT. They report
+-       * their own IP address (like 10.0.0.4) and not the address in front of the
+-       * NAT. But this is likely the same address that we connected to with our
+-       * command connetion. So if the address given by PASV fails, we fall back
+-       * to the address of the command stream.
+-       */
+-      addr = g_vfs_ftp_task_create_remote_address (task, port1 << 8 | port2);
+-      if (addr == NULL)
+-        return G_VFS_FTP_METHOD_ANY;
+-      success = g_vfs_ftp_connection_open_data_connection (task->conn,
+-                                                           addr,
+-                                                           task->cancellable,
+-                                                           &task->error);
+-      g_object_unref (addr);
+-      if (success)
+-        return G_VFS_FTP_METHOD_PASV_ADDR;
+-    }
++  addr = g_vfs_ftp_task_create_remote_address (task, port1 << 8 | port2);
++  if (addr == NULL)
++    return G_VFS_FTP_METHOD_ANY;
++  success = g_vfs_ftp_connection_open_data_connection (task->conn,
++                                                       addr,
++                                                       task->cancellable,
++                                                       &task->error);
++  g_object_unref (addr);
++  if (success)
++    return G_VFS_FTP_METHOD_PASV;
+ 
+   return G_VFS_FTP_METHOD_ANY;
+ }
+@@ -1129,7 +1091,6 @@ g_vfs_ftp_task_setup_data_connection (GV
+     [G_VFS_FTP_METHOD_ANY]       = g_vfs_ftp_task_setup_data_connection_any,
+     [G_VFS_FTP_METHOD_EPSV]      = g_vfs_ftp_task_setup_data_connection_epsv,
+     [G_VFS_FTP_METHOD_PASV]      = g_vfs_ftp_task_setup_data_connection_pasv,
+-    [G_VFS_FTP_METHOD_PASV_ADDR] = g_vfs_ftp_task_setup_data_connection_pasv,
+     [G_VFS_FTP_METHOD_EPRT]      = g_vfs_ftp_task_setup_data_connection_eprt,
+     [G_VFS_FTP_METHOD_PORT]      = g_vfs_ftp_task_setup_data_connection_port
+   };
+@@ -1160,8 +1121,7 @@ g_vfs_ftp_task_setup_data_connection (GV
+         [G_VFS_FTP_METHOD_ANY] = "any",
+         [G_VFS_FTP_METHOD_EPSV] = "EPSV",
+         [G_VFS_FTP_METHOD_PASV] = "PASV",
+-        [G_VFS_FTP_METHOD_PASV_ADDR] = "PASV with workaround",
+-        [G_VFS_FTP_METHOD_EPRT] = "EPRT",
++    [G_VFS_FTP_METHOD_EPRT] = "EPRT",
+         [G_VFS_FTP_METHOD_PORT] = "PORT"
+       };
+       g_atomic_int_set (&task->backend->method, result);

--- a/debian/patches/CVE-2026-28296.patch
+++ b/debian/patches/CVE-2026-28296.patch
@@ -1,0 +1,292 @@
+Index: github-gvfs-CVE-2026-28295/daemon/gvfsbackendftp.c
+===================================================================
+--- github-gvfs-CVE-2026-28295.orig/daemon/gvfsbackendftp.c
++++ github-gvfs-CVE-2026-28295/daemon/gvfsbackendftp.c
+@@ -912,8 +912,14 @@ do_open_for_read (GVfsBackend *backend,
+                                                          error_550_permission_or_not_found, 
+                                                          NULL };
+ 
++  file = g_vfs_ftp_file_new_from_gvfs (ftp, filename, &task.error);
++  if (file == NULL)
++    {
++      g_vfs_ftp_task_done (&task);
++      return;
++    }
++
+   g_vfs_ftp_task_setup_data_connection (&task);
+-  file = g_vfs_ftp_file_new_from_gvfs (ftp, filename);
+ 
+   g_vfs_ftp_task_send_and_check (&task,
+                                  G_VFS_FTP_PASS_100 | G_VFS_FTP_FAIL_200,
+@@ -1033,7 +1039,13 @@ do_create (GVfsBackend *backend,
+   GFileInfo *info;
+   GVfsFtpFile *file;
+ 
+-  file = g_vfs_ftp_file_new_from_gvfs (ftp, filename);
++  file = g_vfs_ftp_file_new_from_gvfs (ftp, filename, &task.error);
++  if (file == NULL)
++    {
++      g_vfs_ftp_task_done (&task);
++      return;
++    }
++
+   info = g_vfs_ftp_dir_cache_lookup_file (ftp->dir_cache, &task, file, FALSE);
+   if (info)
+     {
+@@ -1063,7 +1075,13 @@ do_append (GVfsBackend *backend,
+   GVfsFtpTask task = G_VFS_FTP_TASK_INIT (ftp, G_VFS_JOB (job));
+   GVfsFtpFile *file;
+ 
+-  file = g_vfs_ftp_file_new_from_gvfs (ftp, filename);
++  file = g_vfs_ftp_file_new_from_gvfs (ftp, filename, &task.error);
++  if (file == NULL)
++    {
++      g_vfs_ftp_task_done (&task);
++      return;
++    }
++
+   do_start_write (&task, flags, "APPE %s", g_vfs_ftp_file_get_ftp_path (file));
+   g_vfs_ftp_dir_cache_purge_file (ftp->dir_cache, file);
+   g_vfs_ftp_file_free (file);
+@@ -1085,14 +1103,25 @@ do_replace (GVfsBackend *backend,
+   static const GVfsFtpErrorFunc rnfr_handlers[] = { error_550_permission_or_not_found,
+                                                     NULL };
+ 
+-  file = g_vfs_ftp_file_new_from_gvfs (ftp, filename);
++  file = g_vfs_ftp_file_new_from_gvfs (ftp, filename, &task.error);
++  if (file == NULL)
++    {
++      g_vfs_ftp_task_done (&task);
++      return;
++    }
+ 
+   if (make_backup)
+     {
+       GFileInfo *info;
+       char *backup_path = g_strconcat (filename, "~", NULL);
+-      backupfile = g_vfs_ftp_file_new_from_gvfs (ftp, backup_path);
++      backupfile = g_vfs_ftp_file_new_from_gvfs (ftp, backup_path, &task.error);
+       g_free (backup_path);
++      if (backupfile == NULL)
++        {
++          g_vfs_ftp_file_free (file);
++          g_vfs_ftp_task_done (&task);
++          return;
++        }
+ 
+       info = g_vfs_ftp_dir_cache_lookup_file (ftp->dir_cache, &task, file, FALSE);
+ 
+@@ -1162,7 +1191,7 @@ do_close_write (GVfsBackend *backend,
+ 
+   stream = g_vfs_ftp_connection_get_data_stream (conn);
+   filename = g_object_get_data (G_OBJECT (stream), "g-vfs-backend-ftp-filename");
+-  file = g_vfs_ftp_file_new_from_gvfs (ftp, filename);
++  file = g_vfs_ftp_file_new_from_gvfs (ftp, filename, NULL);
+ 
+   g_vfs_ftp_task_give_connection (&task, handle);
+   g_vfs_ftp_task_close_data_connection (&task);
+@@ -1215,7 +1244,13 @@ do_query_info (GVfsBackend *backend,
+   GVfsFtpFile *file;
+   GFileInfo *real;
+  
+-  file = g_vfs_ftp_file_new_from_gvfs (ftp, filename);
++  file = g_vfs_ftp_file_new_from_gvfs (ftp, filename, &task.error);
++  if (file == NULL)
++    {
++      g_vfs_ftp_task_done (&task);
++      return;
++    }
++
+   real = g_vfs_ftp_dir_cache_lookup_file (ftp->dir_cache,
+                                           &task,
+                                           file,
+@@ -1283,7 +1318,12 @@ do_set_attribute (GVfsBackend *backend,
+   GVfsFtpTask task = G_VFS_FTP_TASK_INIT (ftp, G_VFS_JOB (job));
+   GVfsFtpFile *file;
+ 
+-  file = g_vfs_ftp_file_new_from_gvfs (ftp, filename);
++  file = g_vfs_ftp_file_new_from_gvfs (ftp, filename, &task.error);
++  if (file == NULL)
++    {
++      g_vfs_ftp_task_done (&task);
++      return;
++    }
+ 
+   if (strcmp (attribute, G_FILE_ATTRIBUTE_UNIX_MODE) == 0)
+     {
+@@ -1339,7 +1379,13 @@ do_enumerate (GVfsBackend *backend,
+   GVfsFtpFile *dir;
+   GList *list, *walk;
+ 
+-  dir = g_vfs_ftp_file_new_from_gvfs (ftp, dirname);
++  dir = g_vfs_ftp_file_new_from_gvfs (ftp, dirname, &task.error);
++  if (dir == NULL)
++    {
++      g_vfs_ftp_task_done (&task);
++      return;
++    }
++
+   list = g_vfs_ftp_dir_cache_lookup_dir (ftp->dir_cache,
+                                          &task,
+                                          dir,
+@@ -1381,9 +1427,22 @@ do_set_display_name (GVfsBackend *backen
+   GVfsFtpTask task = G_VFS_FTP_TASK_INIT (ftp, G_VFS_JOB (job));
+   GVfsFtpFile *original, *dir, *now;
+ 
+-  original = g_vfs_ftp_file_new_from_gvfs (ftp, filename);
++  original = g_vfs_ftp_file_new_from_gvfs (ftp, filename, &task.error);
++  if (original == NULL)
++    {
++      g_vfs_ftp_task_done (&task);
++      return;
++    }
++
+   dir = g_vfs_ftp_file_new_parent (original);
+   now = g_vfs_ftp_file_new_child (dir, display_name, &task.error);
++  if (now == NULL)
++    {
++      g_vfs_ftp_file_free (original);
++      g_vfs_ftp_file_free (dir);
++      g_vfs_ftp_task_done (&task);
++      return;
++    }
+ 
+   /* Rename a directory that has been "opened" by CWD may fail, so cd to root first */
+   g_vfs_ftp_task_try_cd (&task, ftp->root);
+@@ -1416,7 +1475,13 @@ do_delete (GVfsBackend *backend,
+ 
+   /* We try file deletion first. If that fails, we try directory deletion.
+    * The file-first-then-directory order has been decided by coin-toss. */
+-  file = g_vfs_ftp_file_new_from_gvfs (ftp, filename);
++  file = g_vfs_ftp_file_new_from_gvfs (ftp, filename, &task.error);
++  if (file == NULL)
++    {
++      g_vfs_ftp_task_done (&task);
++      return;
++    }
++
+   response = g_vfs_ftp_task_send (&task,
+                 		  G_VFS_FTP_PASS_500,
+                 		  "DELE %s", g_vfs_ftp_file_get_ftp_path (file));
+@@ -1464,7 +1529,13 @@ do_make_directory (GVfsBackend *backend,
+   GVfsFtpFile *file;
+   static const GVfsFtpErrorFunc make_directory_handlers[] = { error_550_exists, error_550_parent_not_found, NULL };
+ 
+-  file = g_vfs_ftp_file_new_from_gvfs (ftp, filename);
++  file = g_vfs_ftp_file_new_from_gvfs (ftp, filename, &task.error);
++  if (file == NULL)
++    {
++      g_vfs_ftp_task_done (&task);
++      return;
++    }
++
+   g_vfs_ftp_task_send_and_check (&task,
+                                  0,
+                                  make_directory_handlers,
+@@ -1522,8 +1593,20 @@ do_move (GVfsBackend *backend,
+       return;
+     }
+ 
+-  srcfile = g_vfs_ftp_file_new_from_gvfs (ftp, source);
+-  destfile = g_vfs_ftp_file_new_from_gvfs (ftp, destination);
++  srcfile = g_vfs_ftp_file_new_from_gvfs (ftp, source, &task.error);
++  if (srcfile == NULL)
++    {
++      g_vfs_ftp_task_done (&task);
++      return;
++    }
++
++  destfile = g_vfs_ftp_file_new_from_gvfs (ftp, destination, &task.error);
++  if (destfile == NULL)
++    {
++      g_vfs_ftp_file_free (srcfile);
++      g_vfs_ftp_task_done (&task);
++      return;
++    }
+   if (g_vfs_ftp_task_try_cd (&task, destfile))
+     {
+       char *basename = g_path_get_basename (source);
+@@ -1663,7 +1746,13 @@ do_pull (GVfsBackend *         backend,
+   goffset total_size = 0;
+   guint64 mtime = 0;
+   
+-  src = g_vfs_ftp_file_new_from_gvfs (ftp, source);
++  src = g_vfs_ftp_file_new_from_gvfs (ftp, source, &task.error);
++  if (src == NULL)
++    {
++      g_vfs_ftp_task_done (&task);
++      return;
++    }
++
+   dest = g_file_new_for_path (local_path);
+ 
+   if (remove_source && (flags & G_FILE_COPY_NO_FALLBACK_FOR_MOVE))
+Index: github-gvfs-CVE-2026-28295/daemon/gvfsftpfile.c
+===================================================================
+--- github-gvfs-CVE-2026-28295.orig/daemon/gvfsftpfile.c
++++ github-gvfs-CVE-2026-28295/daemon/gvfsftpfile.c
+@@ -68,19 +68,29 @@ g_vfs_ftp_file_compute_gvfs_path (const
+  * g_vfs_ftp_file_new_from_gvfs:
+  * @ftp: the ftp backend this file is to be used on
+  * @gvfs_path: gvfs path to create the file from
++ * @error: location to take an eventual error or %NULL
+  *
+- * Constructs a new #GVfsFtpFile representing the given gvfs path.
++ * Constructs a new #GVfsFtpFile representing the given gvfs path. If the
++ * display name is invalid, @error is set and %NULL is returned.
+  *
+- * Returns: a new file
++ * Returns: a new file or %NULL on error
+  **/
+ GVfsFtpFile *
+-g_vfs_ftp_file_new_from_gvfs (GVfsBackendFtp *ftp, const char *gvfs_path)
++g_vfs_ftp_file_new_from_gvfs (GVfsBackendFtp *ftp, const char *gvfs_path, GError **error)
+ {
+   GVfsFtpFile *file;
+ 
+   g_return_val_if_fail (G_VFS_IS_BACKEND_FTP (ftp), NULL);
+   g_return_val_if_fail (gvfs_path != NULL, NULL);
+ 
++  if (strpbrk (gvfs_path, "\r\n") != NULL)
++    {
++      g_set_error_literal (error,
++                           G_IO_ERROR, G_IO_ERROR_INVALID_FILENAME,
++                           _("Filename contains invalid characters."));
++      return NULL;
++    }
++
+   file = g_slice_new (GVfsFtpFile);
+   file->backend = g_object_ref (ftp);
+   file->gvfs_path = g_strdup (gvfs_path);
+@@ -136,7 +146,7 @@ g_vfs_ftp_file_new_parent (const GVfsFtp
+     return g_vfs_ftp_file_copy (file);
+ 
+   dirname = g_path_get_dirname (file->gvfs_path);
+-  dir = g_vfs_ftp_file_new_from_gvfs (file->backend, dirname);
++  dir = g_vfs_ftp_file_new_from_gvfs (file->backend, dirname, NULL);
+   g_free (dirname);
+ 
+   return dir;
+@@ -172,7 +182,7 @@ g_vfs_ftp_file_new_child (const GVfsFtpF
+     }
+ 
+   new_path = g_strconcat (parent->gvfs_path, parent->gvfs_path[1] == 0 ? "" : "/", display_name, NULL);
+-  child = g_vfs_ftp_file_new_from_gvfs (parent->backend, new_path);
++  child = g_vfs_ftp_file_new_from_gvfs (parent->backend, new_path, error);
+   g_free (new_path);
+   return child;
+ }
+Index: github-gvfs-CVE-2026-28295/daemon/gvfsftpfile.h
+===================================================================
+--- github-gvfs-CVE-2026-28295.orig/daemon/gvfsftpfile.h
++++ github-gvfs-CVE-2026-28295/daemon/gvfsftpfile.h
+@@ -29,7 +29,8 @@ G_BEGIN_DECLS
+ 
+ 
+ GVfsFtpFile *     g_vfs_ftp_file_new_from_gvfs          (GVfsBackendFtp *       ftp,
+-                                                         const char *           gvfs_path);
++                                                         const char *           gvfs_path,
++                                                         GError **              error);
+ GVfsFtpFile *     g_vfs_ftp_file_new_from_ftp           (GVfsBackendFtp *       ftp,
+                                                          const char *           ftp_path);
+ GVfsFtpFile *     g_vfs_ftp_file_new_parent             (const GVfsFtpFile *    file);

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -11,3 +11,4 @@ add-ftp-socket-timeout.patch
 fix-smb-browse-fail-for-netreset-error.patch
 add-ftp-charset.patch
 feat-sftp-Add-file-directory-monitor-support.patch
+CVE-2026-28295.patch

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -12,3 +12,4 @@ fix-smb-browse-fail-for-netreset-error.patch
 add-ftp-charset.patch
 feat-sftp-Add-file-directory-monitor-support.patch
 CVE-2026-28295.patch
+CVE-2026-28296.patch


### PR DESCRIPTION
## Summary

Fix two FTP security vulnerabilities in the gvfs FTP backend:

### CVE-2026-28295: FTP PASV response SSRF vulnerability
The FTP backend did not validate the IP address returned in the PASV response, allowing a malicious FTP server to trick the client into connecting to an arbitrary address (SSRF). The fix ignores the IP address from the PASV response and always uses the control connection address.

### CVE-2026-28296: FTP path CRLF injection vulnerability
The FTP backend did not validate file paths, allowing paths containing CR/LF characters which could inject arbitrary FTP commands to the server. The fix validates paths and fails with 'Filename contains invalid characters' if CR/LF characters are detected.

## Backport
Upstream MR: https://gitlab.gnome.org/GNOME/gvfs/-/merge_requests/298

## Testing
- `quilt push -a` applies all patches successfully
- Patches are in debian/3.0 (quilt) format

Tags: cve, generated-by-ai